### PR TITLE
Error Handling for NewAgentConfig

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -97,7 +97,10 @@ func New(logger *logrus.Logger, version string) *Agent {
 		pybin = filepath.Join(pd, "py38-x32", "python.exe")
 	}
 
-	ac := NewAgentConfig()
+	ac, err := NewAgentConfig()
+	if err != nil {
+		logger.Fatalln(err)
+	}
 
 	headers := make(map[string]string)
 	if len(ac.Token) > 0 {

--- a/agent/agent_unix.go
+++ b/agent/agent_unix.go
@@ -131,7 +131,7 @@ func (a *Agent) osString() string {
 	return fmt.Sprintf("%s %s %s %s", strings.Title(h.Platform), h.PlatformVersion, h.KernelArch, h.KernelVersion)
 }
 
-func NewAgentConfig() *rmm.AgentConfig {
+func NewAgentConfig() (*rmm.AgentConfig, error) {
 	viper.SetConfigName("tacticalagent")
 	viper.SetConfigType("json")
 	viper.AddConfigPath("/etc/")
@@ -139,7 +139,7 @@ func NewAgentConfig() *rmm.AgentConfig {
 	err := viper.ReadInConfig()
 
 	if err != nil {
-		return &rmm.AgentConfig{}
+		return &rmm.AgentConfig{}, err
 	}
 
 	agentpk := viper.GetString("agentpk")
@@ -159,7 +159,7 @@ func NewAgentConfig() *rmm.AgentConfig {
 		NatsProxyPort:    viper.GetString("natsproxyport"),
 		NatsStandardPort: viper.GetString("natsstandardport"),
 	}
-	return ret
+	return ret, nil
 }
 
 func (a *Agent) RunScript(code string, shell string, args []string, timeout int, runasuser bool) (stdout, stderr string, exitcode int, e error) {

--- a/agent/agent_windows.go
+++ b/agent/agent_windows.go
@@ -47,10 +47,10 @@ var (
 	getDriveType = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetDriveTypeW")
 )
 
-func NewAgentConfig() *rmm.AgentConfig {
+func NewAgentConfig() (*rmm.AgentConfig, error) {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\TacticalRMM`, registry.ALL_ACCESS)
 	if err != nil {
-		return &rmm.AgentConfig{}
+		return &rmm.AgentConfig{}, err
 	}
 
 	baseurl, _, _ := k.GetStringValue("BaseURL")
@@ -79,7 +79,7 @@ func NewAgentConfig() *rmm.AgentConfig {
 		NatsProxyPath:    natsProxyPath,
 		NatsProxyPort:    natsProxyPort,
 		NatsStandardPort: natsStandardPort,
-	}
+	}, nil
 }
 
 func (a *Agent) RunScript(code string, shell string, args []string, timeout int, runasuser bool) (stdout, stderr string, exitcode int, e error) {


### PR DESCRIPTION
If NewAgentConfig had an error an empty agent config would be returned and the agent would continue.
Added error handling for the instance an empty config was returned and logged the error.