### PR TITLE
"Send Command" shell whitespace fix

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -306,7 +306,8 @@ func (a *Agent) CmdV2(c *CmdOptions) CmdStatus {
 	} else if c.IsExecutable {
 		envCmd = gocmd.NewCmdOptions(cmdOptions, c.Shell, c.Command) // c.Shell: bin + c.Command: args as one string
 	} else {
-		envCmd = gocmd.NewCmdOptions(cmdOptions, c.Shell, "-c", c.Command) // /bin/bash -c 'ls -l /var/log/...'
+		commandArray := append(strings.Fields(c.Shell), "-c", c.Command)
+		envCmd = gocmd.NewCmdOptions(cmdOptions, commandArray[0], commandArray[1:]...) // /bin/bash -c 'ls -l /var/log/...'
 	}
 
 	var stdoutBuf bytes.Buffer


### PR DESCRIPTION
If you try to use `/usr/bin/env bash` as the custom shell in `Send Command`, no output is returned. This is because gocmd wants the first parameter to be the executable, with everything else being arguments afterwards.

This simple 2 line patch fixes aforementioned issue. This is useful on systems like NixOS, where bash is not in an easily identifiable location, so you have to use the above syntax.

I do not know if this code would be useful in the other cases in the if statement - if so, I could update the patch to include those.

Thanks in advance!