### PR TITLE
Change Default Script Location on Nix Systems

### DIFF
--- a/agent/utils.go
+++ b/agent/utils.go
@@ -451,7 +451,7 @@ func createNixTmpFile(shell ...string) (*os.File, error) {
 		}
  	}
 
-	f, err = os.CreateTemp(dirPath, fmt.Sprintf("trmm*%s", ext))
+	f, err := os.CreateTemp(dirPath, fmt.Sprintf("trmm*%s", ext))
 	if err != nil {
 		return f, err
 	}

--- a/agent/utils.go
+++ b/agent/utils.go
@@ -433,19 +433,25 @@ func getCwd() (string, error) {
 	return filepath.Dir(self), nil
 }
 
+
 func createNixTmpFile(shell ...string) (*os.File, error) {
 	var f *os.File
-	cwd, err := getCwd()
-	if err != nil {
-		return f, err
-	}
 
 	ext := ""
 	if len(shell) > 0 && shell[0] == "deno" {
 		ext = ".ts"
 	}
 
-	f, err = os.CreateTemp(cwd, fmt.Sprintf("trmm*%s", ext))
+	dirPath := "/tmp/trmm"
+
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		err := os.MkdirAll(dirPath, 0700) // only we have access
+		if err != nil {
+			return f, err
+		}
+ 	}
+
+	f, err = os.CreateTemp(dirPath, fmt.Sprintf("trmm*%s", ext))
 	if err != nil {
 		return f, err
 	}


### PR DESCRIPTION
Currently, scripts are being run from the executable location on *nix systems. This does not work when using read-only filesystems.

Instead, using `/tmp/trmm` ensures that we have a read/write directory location.

Fixes #39 

(I have been using a similar patch to this on most of my systems for at least a year, and have not noticed any issues)