### PR TITLE
fix: updated nushell url release schemes

### DIFF
--- a/agent/agent_unix.go
+++ b/agent/agent_unix.go
@@ -665,8 +665,8 @@ func (a *Agent) InstallNushell(force bool) {
 		case "darwin":
 			switch runtime.GOARCH {
 			case "arm64":
-				// https://github.com/nushell/nushell/releases/download/0.87.0/nu-0.87.0-aarch64-darwin-full.tar.gz
-				assetName = fmt.Sprintf("nu-%s-aarch64-darwin-full.tar.gz", conf.InstallNushellVersion)
+				// https://github.com/nushell/nushell/releases/download/0.106.1/nu-0.106.1-aarch64-apple-darwin.tar.gz
+				assetName = fmt.Sprintf("nu-%s-aarch64-apple-darwin.tar.gz", conf.InstallNushellVersion)
 			default:
 				a.Logger.Debugln("InstallNushell(): Unsupported architecture and OS:", runtime.GOARCH, runtime.GOOS)
 				return
@@ -674,11 +674,11 @@ func (a *Agent) InstallNushell(force bool) {
 		case "linux":
 			switch runtime.GOARCH {
 			case "amd64":
-				// https://github.com/nushell/nushell/releases/download/0.87.0/nu-0.87.0-x86_64-linux-musl-full.tar.gz
-				assetName = fmt.Sprintf("nu-%s-x86_64-linux-musl-full.tar.gz", conf.InstallNushellVersion)
+				// https://github.com/nushell/nushell/releases/download/0.106.1/nu-0.106.1-x86_64-unknown-linux-musl.tar.gz
+				assetName = fmt.Sprintf("nu-%s-x86_64-unknown-linux-musl.tar.gz", conf.InstallNushellVersion)
 			case "arm64":
-				// https://github.com/nushell/nushell/releases/download/0.87.0/nu-0.87.0-aarch64-linux-gnu-full.tar.gz
-				assetName = fmt.Sprintf("nu-%s-aarch64-linux-gnu-full.tar.gz", conf.InstallNushellVersion)
+				// https://github.com/nushell/nushell/releases/download/0.106.1/nu-0.106.1-aarch64-unknown-linux-musl.tar.gz
+				assetName = fmt.Sprintf("nu-%s-aarch64-unknown-linux-musl.tar.gz", conf.InstallNushellVersion)
 			default:
 				a.Logger.Debugln("InstallNushell(): Unsupported architecture and OS:", runtime.GOARCH, runtime.GOOS)
 				return

--- a/agent/agent_windows.go
+++ b/agent/agent_windows.go
@@ -985,11 +985,11 @@ func (a *Agent) InstallNushell(force bool) {
 		case "windows":
 			switch runtime.GOARCH {
 			case "amd64":
-				// https://github.com/nushell/nushell/releases/download/0.87.0/nu-0.87.0-x86_64-windows-msvc-full.zip
-				assetName = fmt.Sprintf("nu-%s-x86_64-windows-msvc-full.zip", conf.InstallNushellVersion)
+				// https://github.com/nushell/nushell/releases/download/0.106.1/nu-0.106.1-x86_64-pc-windows-msvc.zip
+				assetName = fmt.Sprintf("nu-%s-x86_64-pc-windows-msvc.zip", conf.InstallNushellVersion)
 			case "arm64":
-				// https://github.com/nushell/nushell/releases/download/0.87.0/nu-0.87.0-aarch64-windows-msvc-full.zip
-				assetName = fmt.Sprintf("nu-%s-aarch64-windows-msvc-full.zip", conf.InstallNushellVersion)
+				// https://github.com/nushell/nushell/releases/download/0.106.1/nu-0.106.1-aarch64-pc-windows-msvc.zip
+				assetName = fmt.Sprintf("nu-%s-aarch64-pc-windows-msvc.zip", conf.InstallNushellVersion)
 			default:
 				a.Logger.Debugln("InstallNushell(): Unsupported architecture and OS:", runtime.GOARCH, runtime.GOOS)
 				return


### PR DESCRIPTION
This updates the nushell release naming scheme used in later versions.

Reference: https://github.com/nushell/nushell/releases/tag/0.106.1