### PR TITLE
Define Custom Temp Directory for Unix Hosts

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -267,6 +267,7 @@ func New(logger *logrus.Logger, version string) *Agent {
 		SystemDrive:        sd,
 		WinTmpDir:          winTempDir,
 		WinRunAsUserTmpDir: winRunAsUserTmpDir,
+		UnixTmpDir:         ac.UnixTmpDir,
 		MeshInstaller:      "meshagent.exe",
 		MeshSystemEXE:      MeshSysExe,
 		MeshSVC:            meshSvcName,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -54,6 +54,7 @@ type Agent struct {
 	EXE                string
 	SystemDrive        string
 	WinTmpDir          string
+	UnixTmpDir         string
 	WinRunAsUserTmpDir string
 	MeshInstaller      string
 	MeshSystemEXE      string

--- a/agent/agent_unix.go
+++ b/agent/agent_unix.go
@@ -165,7 +165,7 @@ func NewAgentConfig() *rmm.AgentConfig {
 		NatsStandardPort: viper.GetString("natsstandardport"),
 		NatsPingInterval: viper.GetInt("natspinginterval"),
 		Insecure:         viper.GetString("insecure"),
-		UnixTmpDir:       viper.GetString("unixtmpdir"),
+		UnixTmpDir:       viper.GetString("tmpdir"),
 	}
 	return ret
 }

--- a/agent/agent_unix.go
+++ b/agent/agent_unix.go
@@ -165,6 +165,7 @@ func NewAgentConfig() *rmm.AgentConfig {
 		NatsStandardPort: viper.GetString("natsstandardport"),
 		NatsPingInterval: viper.GetInt("natspinginterval"),
 		Insecure:         viper.GetString("insecure"),
+		UnixTmpDir:       viper.GetString("unixtmpdir"),
 	}
 	return ret
 }
@@ -173,7 +174,7 @@ func (a *Agent) RunScript(code string, shell string, args []string, timeout int,
 	code = removeWinNewLines(code)
 	content := []byte(code)
 
-	f, err := createNixTmpFile(shell)
+	f, err := createNixTmpFile(a.UnixTmpDir, shell)
 	if err != nil {
 		a.Logger.Errorln("RunScript createNixTmpFile()", err)
 		return "", err.Error(), 85, err
@@ -368,7 +369,7 @@ func (a *Agent) AgentUpdate(url, inno, version string) error {
 }
 
 func (a *Agent) AgentUninstall(code string) {
-	f, err := createNixTmpFile()
+	f, err := createNixTmpFile(a.UnixTmpDir)
 	if err != nil {
 		a.Logger.Errorln("AgentUninstall createNixTmpFile():", err)
 		return

--- a/agent/install.go
+++ b/agent/install.go
@@ -50,6 +50,7 @@ type Installer struct {
 	MeshNodeID       string
 	Insecure         bool
 	NatsStandardPort string
+	TmpDir           string
 }
 
 func (a *Agent) Install(i *Installer) {
@@ -162,7 +163,7 @@ func (a *Agent) Install(i *Installer) {
 		case "windows":
 			meshOutput = filepath.Join(a.ProgramDir, a.MeshInstaller)
 		case "darwin":
-			tmp, err := createNixTmpFile()
+			tmp, err := createNixTmpFile(a.UnixTmpDir)
 			if err != nil {
 				a.Logger.Fatalln("Failed to create mesh temp file", err)
 			}
@@ -245,7 +246,7 @@ func (a *Agent) Install(i *Installer) {
 	a.Logger.Debugln("Agent token:", agentToken)
 	a.Logger.Debugln("Agent PK:", agentPK)
 
-	createAgentConfig(baseURL, a.AgentID, i.SaltMaster, agentToken, strconv.Itoa(agentPK), i.Cert, i.Proxy, i.MeshDir, i.NatsStandardPort, i.Insecure)
+	createAgentConfig(baseURL, a.AgentID, i.SaltMaster, agentToken, strconv.Itoa(agentPK), i.Cert, i.Proxy, i.MeshDir, i.NatsStandardPort, i.Insecure, i.TmpDir)
 	time.Sleep(1 * time.Second)
 	// refresh our agent with new values
 	a = New(a.Logger, a.Version)

--- a/agent/install_unix.go
+++ b/agent/install_unix.go
@@ -33,7 +33,7 @@ func (a *Agent) installerMsg(msg, alert string, silent bool) {
 	}
 }
 
-func createAgentConfig(baseurl, agentid, apiurl, token, agentpk, cert, proxy, meshdir, natsport string, insecure bool) {
+func createAgentConfig(baseurl, agentid, apiurl, token, agentpk, cert, proxy, meshdir, natsport string, insecure bool, unixtmpdir string) {
 	viper.SetConfigType("json")
 	viper.Set("baseurl", baseurl)
 	viper.Set("agentid", agentid)
@@ -44,6 +44,8 @@ func createAgentConfig(baseurl, agentid, apiurl, token, agentpk, cert, proxy, me
 	viper.Set("proxy", proxy)
 	viper.Set("meshdir", meshdir)
 	viper.Set("natsstandardport", natsport)
+	viper.Set("tmpdir", unixtmpdir)
+
 	if insecure {
 		viper.Set("insecure", "true")
 	}

--- a/agent/install_windows.go
+++ b/agent/install_windows.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-func createAgentConfig(baseurl, agentid, apiurl, token, agentpk, cert, proxy, meshdir, natsport string, insecure bool) {
+func createAgentConfig(baseurl, agentid, apiurl, token, agentpk, cert, proxy, meshdir, natsport string, insecure bool, tmpdir string) {
 	k, _, err := registry.CreateKey(registry.LOCAL_MACHINE, `SOFTWARE\TacticalRMM`, registry.ALL_ACCESS)
 	if err != nil {
 		log.Fatalln("Error creating registry key:", err)
@@ -85,6 +85,13 @@ func createAgentConfig(baseurl, agentid, apiurl, token, agentpk, cert, proxy, me
 		err = k.SetStringValue("Insecure", "true")
 		if err != nil {
 			log.Fatalln("Error creating Insecure registry key:", err)
+		}
+	}
+
+	if len(tmpdir) > 0 {
+		err = k.SetStringValue("TmpDir", tmpdir)
+		if err != nil {
+			log.Fatalln("Error creating TmpDir registry key:", err)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	localMesh := flag.String("local-mesh", "", "Path to mesh executable")
 	noMesh := flag.Bool("nomesh", false, "Do not install mesh agent")
 	meshDir := flag.String("meshdir", "", "Path to custom meshcentral dir")
+	tmpDir := flag.String("tmpdir", "", "Path to custom temp dir")
 	meshNodeID := flag.String("meshnodeid", "", "Mesh Node ID")
 	cert := flag.String("cert", "", "Path to domain CA .pem")
 	silent := flag.Bool("silent", false, "Do not popup any message boxes during installation")
@@ -166,6 +167,7 @@ func main() {
 			MeshNodeID:       *meshNodeID,
 			Insecure:         *insecure,
 			NatsStandardPort: *natsport,
+			TmpDir:           *tmpDir,
 		})
 	default:
 		agent.ShowStatus(version)

--- a/shared/types.go
+++ b/shared/types.go
@@ -43,6 +43,7 @@ type AgentConfig struct {
 	Proxy              string
 	CustomMeshDir      string
 	WinTmpDir          string
+	UnixTmpDir         string
 	WinRunAsUserTmpDir string
 	NatsProxyPath      string
 	NatsProxyPort      string


### PR DESCRIPTION
As discussed in a previous pull request (#55), here is a new patch that allows setting an optional tmpdir for Unix hosts. The functionality also exists for Windows hosts, however it is not been fully implemented. My use case is primarily for NixOS systems.

This does not change the default / existing functionality. It adds a new flag for the installer (`-tmpdir`), and a new config option in the `/etc/tacticalagent` file for a `tmpdir`.

Fixes #39 